### PR TITLE
remove queue expires policy

### DIFF
--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -164,7 +164,7 @@ write_files:
         docker exec rabbitmq rabbitmqctl set_user_tags admin administrator
         docker exec rabbitmq rabbitmqctl add_user rabbit ${rabbit_password}
         docker exec rabbitmq rabbitmqctl add_vhost /
-        docker exec rabbitmq rabbitmqctl set_policy -p / ha-three "^" '{"ha-mode":"exactly", "ha-params":${sync_node_count}, "ha-sync-mode":"automatic", "message-ttl":${message_timeout}, "expires":${message_timeout}}'
+        docker exec rabbitmq rabbitmqctl set_policy -p / ha-three "^" '{"ha-mode":"exactly", "ha-params":${sync_node_count}, "ha-sync-mode":"automatic", "message-ttl":${message_timeout}}'
         docker exec rabbitmq rabbitmqctl set_permissions -p / admin ".*" ".*" ".*"
         docker exec rabbitmq rabbitmqctl set_permissions -p / rabbit ".*" ".*" ".*"
         docker exec rabbitmq rabbitmqctl delete_user guest


### PR DESCRIPTION
We dont want the default policy for queues to expire after 3 days of inactivity 