### PR TITLE
TECH-378: Add new IAM resources with region names 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.lock.info
 .terraform
 .idea
+*.iml

--- a/iam-new.tf
+++ b/iam-new.tf
@@ -7,7 +7,7 @@ resource "aws_iam_role_policy" "iam_policy" {
 }
 
 resource "aws_iam_instance_profile" "iam_profile" {
-  name_prefix = "${local.cluster_name}-${data.aws_region.current.name}"
+  name_prefix = "${local.cluster_name}-${data.aws_region.current.name}-"
   role        = aws_iam_role.iam_role.name
 }
 

--- a/iam-new.tf
+++ b/iam-new.tf
@@ -1,0 +1,18 @@
+# New resources to replace the existing with region specific naming
+resource "aws_iam_role_policy" "iam_policy" {
+  name = "${local.cluster_name}-${data.aws_region.current.name}"
+  role = aws_iam_role.iam_role.id
+
+  policy = data.aws_iam_policy_document.policy_permissions_doc.json
+}
+
+resource "aws_iam_instance_profile" "iam_profile" {
+  name_prefix = "${local.cluster_name}-${data.aws_region.current.name}"
+  role        = aws_iam_role.iam_role.name
+}
+
+resource "aws_iam_role" "iam_role" {
+  name               = "${local.cluster_name}-${data.aws_region.current.name}"
+  assume_role_policy = data.aws_iam_policy_document.policy_doc.json
+  tags               = var.tags
+}

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,7 @@ data "template_file" "cloud-init" {
   }
 }
 
+# To be replaced
 resource "aws_iam_role" "role" {
   name               = local.cluster_name
   assume_role_policy = data.aws_iam_policy_document.policy_doc.json
@@ -121,6 +122,7 @@ data "aws_iam_policy_document" "policy_permissions_doc" {
   }
 }
 
+# To be replaced
 resource "aws_iam_role_policy" "policy" {
   name = local.cluster_name
   role = aws_iam_role.role.id
@@ -128,6 +130,7 @@ resource "aws_iam_role_policy" "policy" {
   policy = data.aws_iam_policy_document.policy_permissions_doc.json
 }
 
+# To be replaced
 resource "aws_iam_instance_profile" "profile" {
   name_prefix = local.cluster_name
   role        = aws_iam_role.role.name


### PR DESCRIPTION
## Description 

Created a separate file with new replacement resources appending region name to the iam resources. Idea is to have the resources created and available for cutover and then in a separate PR, update the launch configuration with the new instance profile. We can clean up the iam-new.tf file into the main.tf file after old resources are deleted. 

Another option would be to append region name to the module interface in CMW for any newly deployed rmq clusters. Although this will name everything in that region (ec2 resources included) with the region suffix and will leave `us-east-1` resources the odd one out without any resources with region name appended. But I'm not opposed to that idea either. 

## To do 

May take some time and we may want to couple the LC swap with [TECH-334](https://smartrent.atlassian.net/browse/TECH-334)
- Apply to all envs
- New PR to swap the LC instance-profile (potentially with/after TECH-334)
- Swap LCs 
- New PR to delete old IAM resources 