### PR TITLE
TECH: Specify AMI ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ resource "aws_security_group" "rabbitmq_nodes" {
 
 resource "aws_launch_configuration" "rabbitmq" {
   name_prefix          = local.cluster_name
-  image_id             = var.ami_id ? var.ami_id : data.aws_ami_ids.amazon-linux-2.ids[0]
+  image_id             = var.ami_id != "" ? var.ami_id : data.aws_ami_ids.amazon-linux-2.ids[0]
   instance_type        = var.instance_type
   key_name             = var.ssh_key_name
   security_groups      = flatten([aws_security_group.rabbitmq_nodes.id, var.nodes_additional_security_group_ids])

--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ resource "aws_security_group" "rabbitmq_nodes" {
 
 resource "aws_launch_configuration" "rabbitmq" {
   name_prefix          = local.cluster_name
-  image_id             = data.aws_ami_ids.amazon-linux-2.ids[0]
+  image_id             = var.ami_id ? var.ami_id : data.aws_ami_ids.amazon-linux-2.ids[0]
   instance_type        = var.instance_type
   key_name             = var.ssh_key_name
   security_groups      = flatten([aws_security_group.rabbitmq_nodes.id, var.nodes_additional_security_group_ids])

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,10 @@ variable "name" {
   default = "main"
 }
 
+variable "ami_id" {
+  description = "The AMI ID to use for the ec2 instance"
+}
+
 variable "min_size" {
   description = "Minimum number of RabbitMQ nodes"
   default     = 2

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,7 @@ variable "name" {
 
 variable "ami_id" {
   description = "The AMI ID to use for the ec2 instance"
+  default     = ""
 }
 
 variable "min_size" {


### PR DESCRIPTION
I got a little distracted by this while looking into region naming changes and then saw this ticket https://smartrent.atlassian.net/browse/TECH-334. 

Shall we do something like this? Then we can pass the AMI ID var up to CMW and handle updating it there. 

Some concerns (more of how to handle this moving forward): 
- Does the public image have an EOL (like if it gets removed after a certain age)?
- Do we want to set up some kind of lifecycle cadence (how often do we/should we update this image)? Once a quarter or something similar maybe.

## Tests 

Just ran some terrform plans in CMW dev with and without setting the var.
