### PR TITLE
TECH: Adding a script to allow for forgetting old hosts

### DIFF
--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -112,6 +112,12 @@ write_files:
               }
       }
 
+  - path: /root/forget_hosts.sh
+    content: |
+        #!/usr/bin/env bash
+        NODE=$1
+        docker exec rabbitmq rabbitmqctl forget_cluster_node $1
+
   - path: /root/find_hosts.sh
     content: |
         #!/usr/bin/env bash


### PR DESCRIPTION
## Description 

Just a small script to add to the hosts in order to allow us to clean up after an instance replacement. 

Noting that rabbit will not allow you to forget a host if it is part of the cluster and rmq is running. A nice safeguard to prevent incorrect forgetting of hosts. 