### PR TITLE
TECH-560: Adjustments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -261,7 +261,7 @@ resource "aws_autoscaling_group" "rabbitmq" {
   min_size                  = var.min_size
   desired_capacity          = var.desired_size
   max_size                  = var.max_size
-  health_check_grace_period = 300
+  health_check_grace_period = var.health_check_grace_period
   health_check_type         = "ELB"
   force_delete              = true
   launch_configuration      = aws_launch_configuration.rabbitmq.name
@@ -297,10 +297,10 @@ resource "aws_elb" "elb" {
   }
 
   health_check {
-    interval            = 30
-    unhealthy_threshold = 10
-    healthy_threshold   = 2
-    timeout             = 3
+    interval            = var.health_check_interval
+    unhealthy_threshold = var.unhealthy_threshold
+    healthy_threshold   = var.healthy_threshold
+    timeout             = var.timeout
     target              = "TCP:5672"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -61,7 +61,7 @@ variable "instance_type" {
 
 variable "instance_volume_type" {
   type        = string
-  description = ""
+  description = "The instance volume type to use (standard, gp2, gp3, st1, sc1, io1)"
   default     = "standard"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,7 @@ variable "ecr_registry_id" {
 }
 
 variable "log_retention_in_days" {
-  type        = string
+  type        = number
   description = "The length of time to retain cloudwatch logs in days"
   default     = 365
 }
@@ -106,7 +106,7 @@ variable "access_log_bucket_prefix" {
 }
 
 variable "access_log_interval" {
-  type        = string
+  type        = number
   description = "How often for the ELB to publish access logs in minutes"
   default     = 60
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,117 +2,174 @@ variable "vpc_id" {
 }
 
 variable "ssh_key_name" {
+  type        = string
+  description = "The ssh key to provide the instance to use for ssh login"
 }
 
 variable "name" {
-  default = "main"
+  type        = string
+  description = "The name of the RabbitMQ cluster"
+  default     = "main"
 }
 
 variable "ami_id" {
+  type        = string
   description = "The AMI ID to use for the ec2 instance"
   default     = ""
 }
 
 variable "min_size" {
+  type        = number
   description = "Minimum number of RabbitMQ nodes"
   default     = 2
 }
 
 variable "desired_size" {
+  type        = number
   description = "Desired number of RabbitMQ nodes"
   default     = 2
 }
 
 variable "max_size" {
+  type        = number
   description = "Maximum number of RabbitMQ nodes"
   default     = 2
 }
 
 variable "subnet_ids" {
-  description = "Subnets for RabbitMQ nodes"
   type        = list(string)
+  description = "Subnets for RabbitMQ nodes"
 }
 
 variable "nodes_additional_security_group_ids" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  description = "List of additional node security group ids"
+  default     = []
 }
 
 variable "elb_additional_security_group_ids" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  description = "List of additional ELB security group ids"
+  default     = []
 }
 
 variable "instance_type" {
-  default = "m5.large"
+  type        = string
+  description = "The EC2 instance type to use"
+  default     = "m5.large"
 }
 
 variable "instance_volume_type" {
-  default = "standard"
+  type        = string
+  description = ""
+  default     = "standard"
 }
 
 variable "instance_volume_size" {
-  default = "0"
+  type        = number
+  description = "The size of the instance volume in gigabytes"
+  default     = 0
 }
 
 variable "instance_volume_iops" {
-  default = "0"
+  type        = number
+  description = "The amount of provisioned iops"
+  default     = 0
 }
 
 variable "rabbitmq_image" {
-  type = string
+  type        = string
+  description = "The Rabbitmq docker image"
 }
 
 variable "ecr_registry_id" {
-  type = string
+  type        = string
+  description = "The ECR registry ID"
 }
 
 variable "log_retention_in_days" {
-  type    = string
-  default = 365
+  type        = string
+  description = "The length of time to retain cloudwatch logs in days"
+  default     = 365
 }
 
 variable "access_log_bucket" {
   type        = string
-  default     = "bucketname"
   description = "optional bucket name to use for access logs"
+  default     = "bucketname"
 }
 
 variable "access_log_bucket_prefix" {
   type        = string
-  default     = ""
   description = "optional prefix to use for access logs"
+  default     = ""
 }
 
 variable "access_log_interval" {
-  type    = string
-  default = 60
+  type        = string
+  description = "How often for the ELB to publish access logs in minutes"
+  default     = 60
 }
 
 variable "access_logs_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  description = "Whether or not to enable access logging on the ELB"
+  default     = false
 }
 
 variable "tags" {
   type        = map(string)
-  default     = {}
   description = "Optional additional Tags to add onto resources this module creates"
+  default     = {}
 }
 
 variable "encrypted_ebs_instance_volume" {
-  type    = bool
-  default = true
+  type        = bool
+  description = "Whether to encrypt the instance ebs volume"
+  default     = true
 }
 
 variable "dd_env" {
-  type = string
+  type        = string
+  description = "The environment the app is running in"
 }
 
 variable "dd_site" {
-  type = string
+  type        = string
+  description = "The Datadog site url"
 }
 
 variable "kms_key_arn" {
-  type = string
+  type        = string
+  description = "The KMS key arn to use for encrypting and decrypting SSM parameters"
+}
+
+variable "health_check_grace_period" {
+  type        = number
+  description = "The ASG health check grace period"
+  default     = 300
+}
+
+variable "health_check_interval" {
+  type        = number
+  description = "The ELB health check interval in seconds"
+  default     = 45
+}
+
+variable "unhealthy_threshold" {
+  type        = number
+  description = "The ELB health check unhealthy threshold count"
+  default     = 10
+}
+
+variable "healthy_threshold" {
+  type        = number
+  description = "The ELB health check healthy threshold count"
+  default     = 2
+}
+
+variable "timeout" {
+  type        = number
+  description = "The ELB health check length of time before timeout in seconds"
+  default     = 3
 }

--- a/variables.tf
+++ b/variables.tf
@@ -147,13 +147,13 @@ variable "kms_key_arn" {
 variable "health_check_grace_period" {
   type        = number
   description = "The ASG health check grace period"
-  default     = 300
+  default     = 400
 }
 
 variable "health_check_interval" {
   type        = number
   description = "The ELB health check interval in seconds"
-  default     = 45
+  default     = 30
 }
 
 variable "unhealthy_threshold" {


### PR DESCRIPTION
## Description 

**Main reason for this PR**: change default ELB health check interval to 45 seconds. Datadog takes a bit longer to install and configure along with some additional dependencies that are needed for using datadog with rabbit and using datadog's secrets management, it all adds up a little bit. This way we can keep using small instances as needed. 
Just making things variables so we can change them as needed. 
Added descriptions to things. 

##Tests

Terraform plan in main app shows only ELB health check interval changing. 