### PR TITLE
TECH: Cleanup unused cloudwatch log refs and tflint addition

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,5 @@
+# Rules and other tflint configuration that should always be used.
+
+rule "terraform_unused_declarations" {
+  enabled = true
+}

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-data "aws_vpc" "vpc" {
-  id = var.vpc_id
-}
-
 data "aws_region" "current" {
 }
 
@@ -54,12 +50,6 @@ data "aws_iam_policy_document" "policy_doc" {
   }
 }
 
-resource "aws_cloudwatch_log_group" "log_group" {
-  name              = var.name
-  retention_in_days = var.log_retention_in_days
-  tags              = var.tags
-}
-
 data "template_file" "cloud-init" {
   template = file("${path.module}/cloud-init.yaml")
 
@@ -92,18 +82,6 @@ data "aws_iam_policy_document" "policy_permissions_doc" {
     ]
     resources = [
       "*"
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-    resources = [
-      "${aws_cloudwatch_log_group.log_group.arn}:*",
-      "${aws_cloudwatch_log_group.log_group.arn}:*:*"
     ]
   }
 
@@ -330,6 +308,7 @@ resource "aws_ssm_parameter" "datadog_api_key" {
   lifecycle {
     ignore_changes = [value]
   }
+  tags = var.tags
 }
 
 resource "aws_ssm_parameter" "datadog_user_password" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,7 +16,3 @@ output "secret_cookie" {
   value     = random_password.secret_cookie.result
   sensitive = true
 }
-
-output "cloudwatch_log_group_name" {
-  value = aws_cloudwatch_log_group.log_group.name
-}

--- a/variables.tf
+++ b/variables.tf
@@ -87,12 +87,6 @@ variable "ecr_registry_id" {
   description = "The ECR registry ID"
 }
 
-variable "log_retention_in_days" {
-  type        = number
-  description = "The length of time to retain cloudwatch logs in days"
-  default     = 365
-}
-
 variable "access_log_bucket" {
   type        = string
   description = "optional bucket name to use for access logs"


### PR DESCRIPTION
## Description 

This is to clean up some unused cloudwatch logs and permissions following deployment to prod and various envs. 
Add missing tags for one of the SSM params. 
Remove unused vars (added tflint rule for unused vars). 
