### PR TITLE
removing the deprecated template file provider

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: smartrent/terraform-ci:0.15.5
+  image: smartrent/terraform-ci:1.1.3
   cpu: 1
 
 base: &base
@@ -13,6 +13,7 @@ format_task:
 tflint_task:
   <<: *base
   tflint_script:
+    - tflint --init
     - tflint
 
 validate_task:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .terraform
 .idea
 *.iml
+.terraform.lock.hcl

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,3 +3,9 @@
 rule "terraform_unused_declarations" {
   enabled = true
 }
+
+plugin "aws" {
+  enabled = true
+  version = "0.12.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-terraform 1.1.5
+terraform 1.1.3
 tflint 0.34.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+terraform 1.1.5
+tflint 0.34.1

--- a/main.tf
+++ b/main.tf
@@ -50,29 +50,6 @@ data "aws_iam_policy_document" "policy_doc" {
   }
 }
 
-data "template_file" "cloud-init" {
-  template = file("${path.module}/cloud-init.yaml")
-
-  vars = {
-    sync_node_count  = var.max_size
-    asg_name         = local.cluster_name
-    region           = data.aws_region.current.name
-    admin_password   = aws_ssm_parameter.rabbit_admin_password.name
-    rabbit_password  = aws_ssm_parameter.rabbit_password.name
-    secret_cookie    = aws_ssm_parameter.secret_cookie.name
-    message_timeout  = 3 * 24 * 60 * 60 * 1000 # 3 days
-    rabbitmq_image   = var.rabbitmq_image
-    rabbitmq_version = join(",", regex("^.+:(.+)$", var.rabbitmq_image))
-    ecr_registry_id  = var.ecr_registry_id
-    dd_api_key       = aws_ssm_parameter.datadog_api_key.name
-    dd_env           = var.dd_env
-    dd_site          = var.dd_site
-    dd_password      = aws_ssm_parameter.datadog_user_password.name
-    app_name         = var.name
-    region           = data.aws_region.current.name
-  }
-}
-
 data "aws_iam_policy_document" "policy_permissions_doc" {
   statement {
     effect = "Allow"
@@ -211,7 +188,26 @@ resource "aws_launch_configuration" "rabbitmq" {
   key_name             = var.ssh_key_name
   security_groups      = flatten([aws_security_group.rabbitmq_nodes.id, var.nodes_additional_security_group_ids])
   iam_instance_profile = aws_iam_instance_profile.iam_profile.id
-  user_data            = data.template_file.cloud-init.rendered
+  user_data = templatefile(
+    file("${path.module}/cloud-init.yaml"),
+    {
+      sync_node_count  = var.max_size
+      asg_name         = local.cluster_name
+      region           = data.aws_region.current.name
+      admin_password   = aws_ssm_parameter.rabbit_admin_password.name
+      rabbit_password  = aws_ssm_parameter.rabbit_password.name
+      secret_cookie    = aws_ssm_parameter.secret_cookie.name
+      message_timeout  = 3 * 24 * 60 * 60 * 1000 # 3 days
+      rabbitmq_image   = var.rabbitmq_image
+      rabbitmq_version = join(",", regex("^.+:(.+)$", var.rabbitmq_image))
+      ecr_registry_id  = var.ecr_registry_id
+      dd_api_key       = aws_ssm_parameter.datadog_api_key.name
+      dd_env           = var.dd_env
+      dd_site          = var.dd_site
+      dd_password      = aws_ssm_parameter.datadog_user_password.name
+      app_name         = var.name
+      region           = data.aws_region.current.name
+  })
 
   root_block_device {
     volume_type           = var.instance_volume_type

--- a/main.tf
+++ b/main.tf
@@ -189,7 +189,7 @@ resource "aws_launch_configuration" "rabbitmq" {
   security_groups      = flatten([aws_security_group.rabbitmq_nodes.id, var.nodes_additional_security_group_ids])
   iam_instance_profile = aws_iam_instance_profile.iam_profile.id
   user_data = templatefile(
-    file("${path.module}/cloud-init.yaml"),
+    "${path.module}/cloud-init.yaml",
     {
       sync_node_count  = var.max_size
       asg_name         = local.cluster_name

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
also adding tflint and fixing the provider declaration.

This deprecated template file provider (which gets included automatically if you use a `template_file` resource is no longer supported and does not have a build compatible with `darwin_arm64`